### PR TITLE
[WIP] first draft thinned

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,0 +1,14 @@
+#! /usr/bin/env node
+
+var _ = require('lodash')
+
+var name = process.argv.slice(2)[0]
+var args = _.filter(process.argv, function(d) {return d !== name})
+
+switch (name) {
+  case 'build':
+    require('binder-build').cli(args)
+    break
+  default:
+    console.error('binder <command(s)> [--flag] [--key=value]')
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "binder-cli",
+  "version": "0.1.0",
+  "description": "command-line tool to manage binder services",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/binder-project/binder-cli.git"
+  },
+  "keywords": [
+    "docker",
+    "binder",
+    "reproduction",
+    "container",
+    "environment",
+    "jupyter"
+  ],
+  "preferGlobal": true,
+  "bin": {
+    "binder": "index.js"
+  },
+  "author": "Jeremy Freeman",
+  "license": "Apache-2.0",
+  "bugs": {
+    "url": "https://github.com/binder-project/binder-cli/issues"
+  },
+  "homepage": "https://github.com/binder-project/binder-cli#readme",
+  "dependencies": {
+    "binder-build": "^0.1.0",
+    "lodash": "^3.10.1"
+  }
+}


### PR DESCRIPTION
This is an alternate draft implementation of the CLI that is far simpler than https://github.com/binder-project/binder-cli/pull/1. Here, there are no options defined in the module itself. Instead, we simply route subcommand names directly to function executions on the full argument list, where those functions could be other modules that expose top-level methods, go binaries, etc.

For example, in this scheme, `binder-build` would, along with defining the build server itself, provide methods for handling submissions and parsing associated options, and this CLI would just dispatch to it. 
